### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/deploy/testgrid-exporter/tmp.yml
+++ b/deploy/testgrid-exporter/tmp.yml
@@ -654,7 +654,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --telemetry-port=8081
         imagePullPolicy: IfNotPresent
-        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.4"
+        image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.4"
         ports:
         - containerPort: 8080
           name: "http"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/k8s.io/issues/4738

**Release note**:
```
Replace all `k8s.gcr.io` references with `registry.k8s.io`
```

cc @kubernetes-sigs/release-engineering 