### PR TITLE
Switch from N1 to E2 machine for cloudbuild

### DIFF
--- a/codebuild.yaml
+++ b/codebuild.yaml
@@ -3,7 +3,7 @@
 timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220617-174ad91c3a
     entrypoint: bash


### PR DESCRIPTION
Reference https://github.com/kubernetes/k8s.io/issues/5059

This changes machine type from N1 to E2 which are newer but almost same pricing. But with E2 being more efficient and overall taking less time. The cost can be reduced.